### PR TITLE
Add option to limit number of threads on a worker.

### DIFF
--- a/Worker.cs
+++ b/Worker.cs
@@ -22,11 +22,13 @@ namespace Resque
         private bool _shutDown;
         private bool _paused;
         private Job _currentJob;
+        private int _maxThreads;
         public string Id { get; set; }
 
-        public Worker(string[] queues)
+        public Worker(string[] queues, int maxThreads = -1)
         {
             _queues = queues;
+            _maxThreads = maxThreads;
             Id = string.Format("{0}:{1}:{2}", Dns.GetHostName(), System.Diagnostics.Process.GetCurrentProcess().Id, String.Join(",", _queues));
         }
 
@@ -63,6 +65,11 @@ namespace Resque
                             if (job != null)
                             {
                                 jobs.Add(job);
+                            }
+
+                            if (_maxThreads >= 0 && jobs.Count >= _maxThreads)
+                            {
+                                break;
                             }
                         } while (job != null);
                     }


### PR DESCRIPTION
Currently, a worker will pull off as many jobs as it possibly can and spin up a thread for each one. The option for a maximum number of threads may be useful depending on the rate of jobs being queued as well as environment constraints.
