### PR TITLE
Fix DateTime Print for Console.

### DIFF
--- a/Worker.cs
+++ b/Worker.cs
@@ -241,7 +241,7 @@ namespace Resque
                     Console.WriteLine("*** " + message);
                     break;
                 case LogType.Verbose:
-                    Console.WriteLine(string.Format("[{0}] {1}", new DateTime().ToString(), message));
+                    Console.WriteLine(string.Format("[{0}] {1}", DateTime.UtcNow.ToString("u"), message));
                     break;
             }
         }


### PR DESCRIPTION
When running in console, Timestamp was not printed properly.

Before

```
[1/1/0001 12:00:00 AM] Found job on fooqueue
[1/1/0001 12:00:00 AM] Checking fooqueue
[1/1/0001 12:00:00 AM] Got fooqueue
[1/1/0001 12:00:00 AM] Got fooqueue
```

Ater Fix

```
[2013-11-08 22:53:44Z] Found job on fooqueue
[2013-11-08 22:53:44Z] Checking fooqueue
[2013-11-08 22:53:44Z] Got fooqueue
[2013-11-08 22:53:44Z] Got fooqueue 
```
