### PR TITLE
Made adjustments to Job to account for non tracked jobs.

### DIFF
--- a/Job.cs
+++ b/Job.cs
@@ -62,13 +62,17 @@ namespace Resque
 
         public void UpdateStatus(int status)
         {
-            var statusInstance = new Status(Payload["id"].ToString());
-            statusInstance.Update(status);
+            var payloadId = Payload["id"];
+            if (payloadId != null)
+            {
+                var statusInstance = new Status(payloadId.ToString());
+                statusInstance.Update(status);
+            }  
         } 
 
         public JObject GetArgs()
         {
-            return Payload["args"] == null ? new JObject() : Payload["args"][0].ToObject<JObject>();
+            return Payload["args"] == null ? new JObject() : JObject.Parse((string)Payload["args"][0]);
         }
 
         public object GetInstance()

--- a/csharp-resque.csproj
+++ b/csharp-resque.csproj
@@ -53,21 +53,20 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.49.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.3.9.49\lib\net35\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common">
+      <HintPath>packages\ServiceStack.Common.3.9.49\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.49.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.3.9.49\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>packages\ServiceStack.Common.3.9.49\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Redis, Version=3.9.49.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Redis.3.9.49\lib\net35\ServiceStack.Redis.dll</HintPath>
+    <Reference Include="ServiceStack.Redis">
+      <HintPath>packages\ServiceStack.Redis.3.9.49\lib\net35\ServiceStack.Redis.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.45.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.3.9.49\lib\net35\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>packages\ServiceStack.Text.3.9.49\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">


### PR DESCRIPTION
Throwing this out there in case you want to merge it into your solution. It may be biased to my implementation.

I'm using node-resque to en-queue jobs and process them with .NET and ran into errors because the jobs didn't have id's. I added a conditional to check if a job has an id prior to updating the status. 

I also ran into issues with using the Nuget package. The Nuget package installs different versions of ServiceStack that didn't match the compiled version referenced in the csharp-resque dll. I'm not sure if this is the right way to fix this so let me know if you want me to separate these changes.