### PR TITLE
dequeue jobs from start of list instead of the end

### DIFF
--- a/Resque.cs
+++ b/Resque.cs
@@ -38,7 +38,7 @@ namespace Resque
         {
             using (var redis = PooledRedisClientManager.GetClient())
             {
-                var data = redis.PopItemFromList(RESQUE_QUEUE_KEY_PREFIX + queue);
+                var data = redis.RemoveStartFromList(RESQUE_QUEUE_KEY_PREFIX + queue);
                 if (data == null) return null;
                 return JsonConvert.DeserializeObject<JObject>(data);
             }


### PR DESCRIPTION
This modifies the dequeuing behavior to be in line with the original php-resque library as well as the general concept of queues as a FIFO data structure.

In my case this was helpful because I implemented logic whereby if a certain task in a job failed, I wanted to retry that job, but not before all the other ones that had already been queued. I wanted to send it to the back of the line, so to speak.